### PR TITLE
Fix typo in links to KeY

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Deductive verification case study in which we formally verify [Java's `IdentityHashMap`] 
 (http://hg.openjdk.java.net/jdk7u/jdk7u/jdk/file/4dd5e486620d/src/share/classes/java/util/IdentityHashMap.java).
 We used the Java Modeling Language [JML](https://www.cs.ucf.edu/~leavens/JML/index.shtml) for formal specification 
-and [KeY](https://www-key-project.org) as interactive theorem prover. 
+and [KeY](https://www.key-project.org) as interactive theorem prover. 
 We used [JJBMC](https://github.com/JonasKlamroth/JJBMC) and [JUnit](https://junit.org) to gain 
 confidence while engineering the specification.
 
@@ -11,7 +11,7 @@ confidence while engineering the specification.
 The specified sources code can be found in the following 4 repositories:
 * [IM9906-2-VerifyingIdentityHashMap](https://github.com/m4ndeb2r/IM9906-2-VerifyingIdentityHashMap) 
   contains the [JML](https://www.cs.ucf.edu/~leavens/JML/index.shtml) specification and the
-  [KeY](https://www-key-project.org) proof files for every proven method. It also contains
+  [KeY](https://www.key-project.org) proof files for every proven method. It also contains
   the binary of the KeY tool that was used to formally verify the `IdentityHashMap`.
 * [IM9906-2-IdentityHashMapSpecTester](https://github.com/m4ndeb2r/IM9906-2-IdentityHashMapSpecTester) contains
   the [JUnit](https://junit.org) tests to gain confidence during the specification engineering process.


### PR DESCRIPTION
I just saw @wadoon working on this and had a look at the `README.md`. That's when I stumbled upon the typos :man_shrugging: 